### PR TITLE
:loud_sound: Include more details in console output when coverage analysis fails due to tests failures

### DIFF
--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -67,6 +67,8 @@ namespace Fettle.Console
                 {
                     var analyser = coverageAnalyserFactory(eventListener);
                     coverageResult = AnalyseCoverage(analyser, outputWriter, parsedArgs.Config);
+
+                    outputWriter.WriteLine(Environment.NewLine);
                     if (!coverageResult.WasSuccessful)
                     {
                         OutputCoverageAnalysisError(coverageResult.ErrorDescription, outputWriter);
@@ -115,14 +117,7 @@ namespace Fettle.Console
             Config config)
         {
             outputWriter.Write("Analysing test coverage");
-
-            var coverageResult = coverageAnalyser.AnalyseCoverage(config).Result;
-            if (coverageResult.WasSuccessful)
-            {            
-                outputWriter.Write(Environment.NewLine);
-            }
-
-            return coverageResult;
+            return coverageAnalyser.AnalyseCoverage(config).Result;
         }
 
         private static MutationTestResult PerformMutationTesting(

--- a/src/Core/CoverageAnalysisResult.cs
+++ b/src/Core/CoverageAnalysisResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -33,9 +34,13 @@ namespace Fettle.Core
 
         internal static ICoverageAnalysisResult Error(string errorDescription)
         {
+            var fullErrorDescription = "Encountered a failing test." +
+                $"{Environment.NewLine}{Environment.NewLine}" +
+                $"{errorDescription}";
+
             return new CoverageAnalysisResult
             {
-                ErrorDescription = errorDescription
+                ErrorDescription = fullErrorDescription
             };
         }
 

--- a/src/Tests/Core/Contexts/Coverage.cs
+++ b/src/Tests/Core/Contexts/Coverage.cs
@@ -49,7 +49,7 @@ namespace Fettle.Tests.Core.Contexts
             };
         }
 
-        protected void Given_some_failing_tests()
+        protected void Given_some_failing_tests(string failingTest)
         {
             var mockTestRunner = new Mock<ITestRunner>();
             mockTestRunner
@@ -57,7 +57,7 @@ namespace Fettle.Tests.Core.Contexts
                 .Returns(new TestRunResult
                 {
                     Status = TestRunStatus.SomeTestsFailed,
-                    Error = "HasSurvivingMutants.Tests.MorePartialNumberComparisonTests.IsGreaterThanOneHundred failed"
+                    Error = $"{failingTest} failed"
                 });
 
             mockTestRunner
@@ -68,7 +68,7 @@ namespace Fettle.Tests.Core.Contexts
                 .Returns(new CoverageTestRunResult
                 {
                     Status = TestRunStatus.SomeTestsFailed,
-                    Error = "HasSurvivingMutants.Tests.MorePartialNumberComparisonTests.IsGreaterThanOneHundred failed"
+                    Error = $"{failingTest} failed"
                 });
 
             testRunner = mockTestRunner.Object;

--- a/src/Tests/Core/Coverage/Tests_fail.cs
+++ b/src/Tests/Core/Coverage/Tests_fail.cs
@@ -9,7 +9,7 @@ namespace Fettle.Tests.Core.Coverage
             Given_an_app_with_tests();
             Given_project_filters("HasSurvivingMutants.Implementation");
 
-            Given_some_failing_tests();
+            Given_some_failing_tests(failingTest: "ExampleTests.TestThatFails");
 
             When_analysing_coverage();
         }
@@ -23,8 +23,7 @@ namespace Fettle.Tests.Core.Coverage
         [Test]
         public void Then_error_description_indicates_the_test_that_failed()
         {
-            Assert.That(Result.ErrorDescription, 
-                Does.Contain("HasSurvivingMutants.Tests.MorePartialNumberComparisonTests.IsGreaterThanOneHundred"));
+            Assert.That(Result.ErrorDescription, Does.Contain("ExampleTests.TestThatFails"));
         }
     }
 }

--- a/src/Tests/Core/ImplementationDetails/NUnitRunResults_Tests.cs
+++ b/src/Tests/Core/ImplementationDetails/NUnitRunResults_Tests.cs
@@ -37,23 +37,29 @@ namespace Fettle.Tests.Core.ImplementationDetails
         }
 
         [Test]
-        public void When_results_xml_indicates_that_some_tests_failed_Then_error_reflects_their_errors()
+        public void When_results_xml_indicates_that_some_tests_failed_Then_error_field_contains_error_info()
         {
             var xmlNode = StringToXmlNode(
                 @"<?xml version=""1.0"" encoding=""utf-8"" standalone=""no""?>
                   <test-run id=""2"" result=""Failed"" total=""2"">
                      <test-suite runstate=""Runnable"">
                         <test-suite runstate=""Runnable"">
-                            <test-case>
+                            <test-case fullname=""HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsPositive"">
                                 <failure>
                                     <message>error message 1</message>
+                                    <stack-trace>
+                                        <![CDATA[   at HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsPositive() in C:\dev\fettle\src\Examples\HasSurvivingMutants\Tests\PartialNumberComparisonTests.cs:line 14 ]]>
+                                    </stack-trace>
                                 </failure>
                             </test-case>
                         </test-suite>
                         <test-suite runstate=""Runnable"">
-                            <test-case>
+                            <test-case fullname=""HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsNegative"">
                                 <failure>
                                     <message>error message 2</message>
+                                    <stack-trace>
+                                        <![CDATA[   at HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsNegative() in C:\dev\fettle\src\Examples\HasSurvivingMutants\Tests\PartialNumberComparisonTests.cs:line 15 ]]>
+                                    </stack-trace>
                                 </failure>
                             </test-case>
                         </test-suite>
@@ -63,8 +69,16 @@ namespace Fettle.Tests.Core.ImplementationDetails
 
             var result = NUnitRunResults.Parse(xmlNode);
 
-            Assert.That(result.Error, Does.Contain("error message 1"));
-            Assert.That(result.Error, Does.Contain("error message 2"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Error, Does.Contain("HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsPositive"));
+                Assert.That(result.Error, Does.Contain("PartialNumberComparisonTests.cs:line 14"));
+                Assert.That(result.Error, Does.Contain("error message 1"));
+
+                Assert.That(result.Error, Does.Contain("HasSurvivingMutants.Tests.PartialNumberComparisonTests.IsNegative"));
+                Assert.That(result.Error, Does.Contain("PartialNumberComparisonTests.cs:line 15"));
+                Assert.That(result.Error, Does.Contain("error message 2"));
+            });
         }
        
         [Test]


### PR DESCRIPTION
Fixes #42 