### PR TITLE
#68 add source exclude filters (identified by exclamation mark)

### DIFF
--- a/src/Core/Internal/Filtering.cs
+++ b/src/Core/Internal/Filtering.cs
@@ -37,10 +37,17 @@ namespace Fettle.Core.Internal
 
             var relativePath = RelativeFilePath(document.FilePath, config);
 
-            var matchesAnyFilter = config.SourceFileFilters
-                .Any(f => Glob.Parse(f).IsMatch(relativePath));
+            var excludeFilters = config.SourceFileFilters.Where(f => f.Contains("!")).Select(f => f.Replace("!", ""));
+            var matchesAnyExcludeFilter = excludeFilters.Any(f => Glob.Parse(f).IsMatch(relativePath));
+            if (matchesAnyExcludeFilter)
+            {
+                return false;
+            }
 
-            return matchesAnyFilter;
+            var includeFilters = config.SourceFileFilters.Where(f => !f.Contains("!"));
+            var matchesAnyIncludeFilter = includeFilters.Any(f => Glob.Parse(f).IsMatch(relativePath));
+
+            return matchesAnyIncludeFilter;
         }
 
         private static bool ShouldMutateAccordingToLocallyModifiedList(Document document, Config config)

--- a/src/Core/Internal/Filtering.cs
+++ b/src/Core/Internal/Filtering.cs
@@ -37,14 +37,14 @@ namespace Fettle.Core.Internal
 
             var relativePath = RelativeFilePath(document.FilePath, config);
 
-            var excludeFilters = config.SourceFileFilters.Where(f => f.Contains("!")).Select(f => f.Replace("!", ""));
+            var excludeFilters = config.SourceFileFilters.Where(f => f.StartsWith("!")).Select(f => f.Replace("!", ""));
             var matchesAnyExcludeFilter = excludeFilters.Any(f => Glob.Parse(f).IsMatch(relativePath));
             if (matchesAnyExcludeFilter)
             {
                 return false;
             }
 
-            var includeFilters = config.SourceFileFilters.Where(f => !f.Contains("!"));
+            var includeFilters = config.SourceFileFilters.Where(f => !f.StartsWith("!"));
             var matchesAnyIncludeFilter = includeFilters.Any(f => Glob.Parse(f).IsMatch(relativePath));
 
             return matchesAnyIncludeFilter;

--- a/src/Tests/Core/ImplementationDetails/ShouldMutateDocument_Tests.cs
+++ b/src/Tests/Core/ImplementationDetails/ShouldMutateDocument_Tests.cs
@@ -5,29 +5,35 @@ using NUnit.Framework;
 namespace Fettle.Tests.Core.ImplementationDetails
 {
     class ShouldMutateDocument_Tests
-    {
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Other*",  @"src\OtherFile.cs",  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Some*",   @"src\OtherFile.cs",  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  null,          @"src\OtherFile.cs",  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Other*",  @"src\SomeFile.cs",   false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Other*",  "",                   false)] 
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Other*",  null,                 false)] 
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Some*",   @"src\SomeFile.cs",   true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Some*",   "",                   false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  @"**\Some*",   null,                 true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  null,          @"src\SomeFile.cs",   true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  null,          "",                   false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",  null,          null,                 true)]
+    {        
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              @"src\SomeFile.cs",  false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              "",                  false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              null,                false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               @"src\SomeFile.cs",  true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               "",                  false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               null,                true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                @"src\SomeFile.cs",  true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                "",                  false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                null,                true)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, @"src\SomeFile.cs", false)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, "",                 false)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, null,               false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, @"src\SomeFile.cs",  true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, "",                  false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, null,                true)]
         public void A_source_file_can_be_skipped_via_filters_or_local_modification_list(
             string sourceFilePath,
-            string sourceFileFilters, 
+            string[] sourceFileFilters, 
             string modifications,
             bool expectedToBeMutatable)
         {
             var config = new Config
             {
                 SolutionFilePath = @"c:\blah\SomeApp.sln",
-                SourceFileFilters = sourceFileFilters == null ? new string[0] : new[]{ sourceFileFilters },
+                SourceFileFilters = sourceFileFilters == null ? new string[0] : sourceFileFilters,
                 LocallyModifiedSourceFiles = modifications == null ? null :
                     (modifications == "" ? new string[0] : new[]{ modifications })
             };

--- a/src/Tests/Core/ImplementationDetails/ShouldMutateDocument_Tests.cs
+++ b/src/Tests/Core/ImplementationDetails/ShouldMutateDocument_Tests.cs
@@ -5,25 +5,25 @@ using NUnit.Framework;
 namespace Fettle.Tests.Core.ImplementationDetails
 {
     class ShouldMutateDocument_Tests
-    {        
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              @"src\OtherFile.cs", false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               @"src\OtherFile.cs", false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                @"src\OtherFile.cs", false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              @"src\SomeFile.cs",  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              "",                  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Other*" },              null,                false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               @"src\SomeFile.cs",  true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               "",                  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*" },               null,                true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                @"src\SomeFile.cs",  true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                "",                  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    null,                                null,                true)]
-        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, @"src\SomeFile.cs", false)]
-        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, "",                 false)]
-        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*",  @"**\!No\*" }, null,               false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, @"src\SomeFile.cs",  true)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, "",                  false)]
-        [TestCase(@"c:\blah\src\SomeFile.cs",    new[] { @"**\Some*",  @"**\!No\*" }, null,                true)]
+    {
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Other*" }, @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*" }, @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", null, @"src\OtherFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Other*" }, @"src\SomeFile.cs", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Other*" }, "", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Other*" }, null, false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*" }, @"src\SomeFile.cs", true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*" }, "", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*" }, null, true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", null, @"src\SomeFile.cs", true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", null, "", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", null, null, true)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, @"src\SomeFile.cs", false)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, "", false)]
+        [TestCase(@"c:\blah\src\No\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, null, false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, @"src\SomeFile.cs", true)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, "", false)]
+        [TestCase(@"c:\blah\src\SomeFile.cs", new[] { @"**\Some*", @"!**\No\*" }, null, true)]
         public void A_source_file_can_be_skipped_via_filters_or_local_modification_list(
             string sourceFilePath,
             string[] sourceFileFilters, 


### PR DESCRIPTION
Hi, 
exclude source filter added according to proposal to issue #68.

I also added the possibility to use more than one filter in the ShouldMutateDocument_Tests and a few more use cases to prove that exclude filters work and do not spoil any other functionality.

Best regards, Alex
